### PR TITLE
feat: add Hello Mark marquee banner

### DIFF
--- a/app/src/components/HelloWorld.vue
+++ b/app/src/components/HelloWorld.vue
@@ -35,6 +35,16 @@ function maskSecret(value: string): string {
 
 <template>
   <div class="container">
+    <div class="marquee-wrapper">
+      <div class="marquee-track">
+        <span>Hello Mark ^^</span>
+        <span>Hello Mark ^^</span>
+        <span>Hello Mark ^^</span>
+        <span>Hello Mark ^^</span>
+        <span>Hello Mark ^^</span>
+      </div>
+    </div>
+
     <h1>🚀 GitOps Practice App</h1>
     <p class="subtitle">Vue 3 + Vite + Docker + Helm + Argo CD + Vault</p>
 
@@ -193,5 +203,28 @@ h1 {
   color: #666;
   font-size: 0.85rem;
   margin-top: 2rem;
+}
+
+.marquee-wrapper {
+  overflow: hidden;
+  background: linear-gradient(90deg, #1a1a2e, #16213e, #1a1a2e);
+  border-radius: 8px;
+  padding: 0.6rem 0;
+  margin-bottom: 1.5rem;
+}
+
+.marquee-track {
+  display: inline-flex;
+  gap: 4rem;
+  white-space: nowrap;
+  animation: marquee 8s linear infinite;
+  font-size: 1.1rem;
+  font-weight: bold;
+  color: #a78bfa;
+}
+
+@keyframes marquee {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
 }
 </style>


### PR DESCRIPTION
## Summary

- 在頁面頂部加入「Hello Mark ^^」紫色跑馬燈
- CSS animation 純前端實作，無外部依賴
- 跑馬燈位於標題上方，頁面載入即滾動

## Test plan

- [ ] Merge 後 GitHub Actions 自動 build & push image
- [ ] Argo CD 偵測 `values.yaml` image tag 變更後自動部署
- [ ] 約 2-3 分鐘後 http://localhost:30080 可看到跑馬燈

🤖 Generated with [Claude Code](https://claude.com/claude-code)