### PR TITLE
ci: implement trunk-based development workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,18 @@
-name: CI - Build and Deploy
+name: CI - Build and Push
 
 on:
   push:
     branches: [main]
     paths:
       - 'app/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/**'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
@@ -14,7 +22,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
 
     steps:
@@ -43,21 +51,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and Push Docker image
         uses: docker/build-push-action@v5
         with:
           context: ./app
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Update image tag in Helm values
-        run: |
-          sed -i "s|tag:.*|tag: \"${{ github.sha }}\"|" \
-            infra/helm/myapp/values.yaml
-          git config user.email "github-actions@github.com"
-          git config user.name "GitHub Actions"
-          git add infra/helm/myapp/values.yaml
-          git commit -m "chore: update image tag to ${{ github.sha }}"
-          git push
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release - Deploy
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/myapp
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: main
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Re-tag image with release version
+        run: |
+          SOURCE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+          RELEASE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}"
+          LATEST_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+
+          docker pull "$SOURCE_TAG"
+          docker tag "$SOURCE_TAG" "$RELEASE_TAG"
+          docker tag "$SOURCE_TAG" "$LATEST_TAG"
+          docker push "$RELEASE_TAG"
+          docker push "$LATEST_TAG"
+
+      - name: Update image tag in Helm values
+        run: |
+          sed -i "s|tag:.*|tag: \"${{ github.ref_name }}\"|" \
+            infra/helm/myapp/values.yaml
+          git config user.email "github-actions@github.com"
+          git config user.name "GitHub Actions"
+          git add infra/helm/myapp/values.yaml
+          git commit -m "chore: release ${{ github.ref_name }}"
+          git push origin main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 專案概述
+
+這是一個完整的 GitOps + CI/CD 學習專案，展示從程式碼推送到 Kubernetes 自動部署的完整流程。
+
+- **Frontend**: Vue 3 + TypeScript + Vite（`app/`）
+- **Container**: Docker multi-stage build → GitHub Container Registry (GHCR)
+- **CI/CD**: GitHub Actions（自動 build、push image、更新 Helm values）
+- **GitOps**: Argo CD 監聽 `infra/helm/myapp/values.yaml` 的 image tag 變更
+- **Secrets**: HashiCorp Vault + Agent Injector（注入 `/vault/secrets/config.json`）
+
+## 常用指令
+
+### Frontend 開發（在 `app/` 目錄下執行）
+
+```bash
+npm install          # 安裝依賴
+npm run dev          # 啟動 Vite dev server（http://localhost:5173）
+npm run build        # TypeScript 型別檢查 + Vite 打包到 dist/
+npm run preview      # 預覽 build 後的靜態輸出
+```
+
+### Docker
+
+```bash
+cd app
+docker build -t myapp:latest .
+docker run -p 3000:80 myapp:latest   # 訪問 http://localhost:3000
+```
+
+### Kubernetes（本機 OrbStack）
+
+```bash
+# 部署 Argo CD
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+
+# 安裝 Vault（可選，用於 secret 示範）
+helm repo add hashicorp https://helm.releases.hashicorp.com
+helm install vault hashicorp/vault -n vault --create-namespace -f infra/helm/vault-values.yaml
+bash infra/scripts/vault-setup.sh   # 初始化 secrets 與 K8s auth
+
+# 建立 Argo CD Application
+kubectl apply -f argocd-application.yaml
+
+# 訪問應用（NodePort）
+http://localhost:30080
+```
+
+## 開發流程（Trunk-Based Development）
+
+### 日常開發
+1. 從 `main` 建立短命 feature branch：`feat/xxx`、`fix/xxx`
+2. 在 feature branch 開發，開 PR 到 `main`
+3. PR 觸發 CI：build Vue app + build Docker image（但**不 push**）
+4. Review 通過後 merge → CI push image（tag: git SHA）
+
+### 部署
+只有打上 release tag 才會部署：
+```bash
+git tag v1.2.0
+git push origin v1.2.0
+```
+觸發 `release.yml`：
+1. Re-tag 既有 image（SHA → v1.2.0 + latest）
+2. 更新 `infra/helm/myapp/values.yaml` 的 `image.tag`
+3. Argo CD 偵測到變更 → 自動同步部署（約 2-3 分鐘完成）
+
+### Branch 保護規則（在 GitHub 設定）
+- `main` branch 需要 PR + CI pass 才能 merge
+- 禁止直接 push to main
+
+## 架構重點
+
+### Vault Secret 注入機制
+
+`infra/helm/myapp/templates/deployment.yaml` 透過 annotation 啟用 Vault Agent Injector：
+
+- Vault Agent 以 sidecar 形式運行，將 `secret/myapp/config` 渲染為 JSON
+- 掛載到 `/vault/secrets/config.json`
+- nginx 設定 `location = /api/config` 直接回傳該檔案（見 `app/nginx.conf`）
+- 前端 `HelloWorld.vue` fetch `/api/config` 取得 secret，並遮罩敏感值
+
+### Image Tag 更新機制
+
+CI pipeline (`ci.yml`) 透過 `sed` 修改 `values.yaml` 並 git commit，Argo CD 以此作為 GitOps 的 trigger，不需要直接操作 K8s cluster。
+
+### Build Time 注入
+
+`app/vite.config.ts` 透過 `define: { __BUILD_TIME__ }` 在 build 時注入時間戳，前端可用 `__BUILD_TIME__` 全域變數顯示部署時間。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,184 @@
+# 部署指南
+
+本文件記錄將 simple-cicd 部署到本機 OrbStack Kubernetes 的完整步驟，以及完整 GitOps 流程說明。
+
+## 前置條件
+
+- [OrbStack](https://orbstack.dev/) 已安裝並啟用 Kubernetes
+- `kubectl` 可用（OrbStack 安裝後自動設定）
+- `helm` 已安裝：`brew install helm`
+- Docker 可用（OrbStack 提供）
+
+## 一次性環境設定
+
+### 1. 安裝 Argo CD
+
+```bash
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+kubectl rollout status deployment/argocd-server -n argocd --timeout=120s
+```
+
+### 2. 設定 GHCR 私有 Repo 存取
+
+Argo CD 需要 GitHub token（需要 `repo` 權限）才能從私有 repo 讀取 Helm chart：
+
+```bash
+kubectl create secret generic argocd-repo-hjom3tp6 \
+  --from-literal=type=git \
+  --from-literal=url=https://github.com/hjom3tp6/simple-cicd \
+  --from-literal=username=hjom3tp6 \
+  --from-literal=password=<GITHUB_TOKEN> \
+  -n argocd
+
+kubectl annotate secret argocd-repo-hjom3tp6 -n argocd "managed-by=argocd.argoproj.io"
+kubectl label secret argocd-repo-hjom3tp6 -n argocd "argocd.argoproj.io/secret-type=repository"
+```
+
+K8s 需要 token（需要 `read:packages` 權限）才能從 GHCR 拉 image：
+
+```bash
+kubectl create namespace myapp
+
+kubectl create secret docker-registry ghcr-secret \
+  --docker-server=ghcr.io \
+  --docker-username=hjom3tp6 \
+  --docker-password=<GITHUB_TOKEN> \
+  -n myapp
+```
+
+### 3. 部署 Argo CD Application
+
+```bash
+kubectl apply -f argocd-application.yaml
+```
+
+Argo CD 會自動從 GitHub 拉取 `infra/helm/myapp/` 並部署。等待同步完成：
+
+```bash
+kubectl get application myapp -n argocd
+# 等到 SYNC STATUS = Synced, HEALTH STATUS = Healthy
+```
+
+### 4. 設定 ServiceAccount 的 imagePullSecrets
+
+Argo CD 部署後，需要手動設定 SA 的 pull secret（Helm chart 目前未內建）：
+
+```bash
+kubectl patch serviceaccount myapp -n myapp \
+  -p '{"imagePullSecrets": [{"name": "ghcr-secret"}]}'
+kubectl rollout restart deployment/myapp -n myapp
+```
+
+## 確認部署狀態
+
+```bash
+# Pod 狀態
+kubectl get pods -n myapp
+
+# Service / Port
+kubectl get svc -n myapp
+
+# Argo CD 同步狀態
+kubectl get application myapp -n argocd -o wide
+```
+
+App 跑起來後可透過 NodePort 存取：**http://localhost:30080**
+
+## Tailscale 網路存取
+
+OrbStack 的 NodePort 預設只綁定 `localhost`，同一 Tailscale VPN 的裝置無法直連。用 `socat` 轉發流量：
+
+```bash
+# 安裝 socat（只需一次）
+brew install socat
+
+# 啟動轉發（100.81.101.47 替換成你的 Tailscale IP）
+nohup socat TCP-LISTEN:30080,bind=100.81.101.47,fork,reuseaddr TCP:localhost:30080 \
+  > /tmp/socat-30080.log 2>&1 &
+```
+
+查詢自己的 Tailscale IP：`tailscale ip -4`
+
+啟動後，同 VPN 裝置可透過 `http://<tailscale-ip>:30080` 存取。
+
+> **注意：** `socat` 是暫時性的，重開機後需要重新執行。如需永久化，設定成 launchd service。
+
+## GitOps 自動部署流程
+
+日常開發只需要：
+
+```bash
+# 修改 app/src/ 下的 Vue 原始碼
+git add . && git commit -m "feat: ..."
+git push
+```
+
+GitHub Actions 會自動：
+1. `npm ci && npm run build`（Vite 打包）
+2. `docker build & push` → GHCR（tag 為 git SHA）
+3. 更新 `infra/helm/myapp/values.yaml` 的 `image.tag`
+4. git commit & push
+
+Argo CD 偵測到 `values.yaml` 變更後，自動 `helm upgrade`，約 2-3 分鐘完成部署。
+
+### 透過 PR 部署
+
+實際開發建議走 PR 流程，讓 CI 在 merge 後才觸發：
+
+```bash
+# 建立 feature branch
+git checkout -b feat/my-feature
+
+# 開發、commit...
+git push -u origin feat/my-feature
+
+# 建立 PR（CLI 方式）
+gh pr create --title "feat: ..." --body "..."
+```
+
+merge PR 後，`main` branch 觸發 CI → 自動部署。CI workflow 只在 `app/**` 有變更時才執行（見 `.github/workflows/ci.yml` 的 `paths` 設定）。
+
+## GitHub Actions 一次性權限設定
+
+第一次讓 GitHub Actions 推 image 到 GHCR，需要設定兩個地方：
+
+### 1. 開啟 Repo 的 Actions 讀寫權限
+
+預設 `GITHUB_TOKEN` 只有讀取權限，推 package 會被拒絕。
+
+前往 **Settings → Actions → General → Workflow permissions**，選擇 **Read and write permissions** 後儲存。
+
+### 2. 授權 Repo 存取已存在的 GHCR Package
+
+如果 package（`ghcr.io/<user>/<repo>/myapp`）曾經用 Personal Access Token（PAT）手動推過，它不會自動允許 `GITHUB_TOKEN` 寫入。
+
+前往：
+```
+https://github.com/users/<your-username>/packages/container/<repo>%2Fmyapp/settings
+```
+
+在 **Manage Actions access** 區塊，點 **Add Repository** → 選目標 repo → 設為 **Write**。
+
+> 這個步驟只需要做一次。之後 CI 推 image 都會使用 `GITHUB_TOKEN`，不需要 PAT。
+
+## 本機 Build（不走 GHCR）
+
+開發時若想快速測試，可直接 build 本機 image：
+
+```bash
+cd app
+docker build -t myapp:local .
+
+helm upgrade myapp ./infra/helm/myapp -n myapp \
+  --set image.repository=myapp \
+  --set image.tag=local \
+  --set image.pullPolicy=Never \
+  --set vault.enabled=false
+```
+
+> 注意：本機 build 後如果 Argo CD auto-sync 仍開啟，它會把 image 打回 GHCR 版本。暫停 sync：
+> ```bash
+> kubectl patch application myapp -n argocd \
+>   -p '{"spec":{"syncPolicy":{"automated":null}}}' --type merge
+> ```


### PR DESCRIPTION
## Summary

- 拆分 CI/CD 為兩個 workflow：`ci.yml`（build）和 `release.yml`（deploy）
- CI 在 PR 和 push to main 時觸發，PR 時只 build 不 push image
- 部署改為手動打 tag 觸發（`v*.*.*`），release 時 re-tag 既有 image，不重新 build
- 加入 Docker layer cache（`type=gha`）和 concurrency cancel-in-progress 節省 Actions 額度
- 更新 CLAUDE.md 說明 TBD 開發流程

## 新流程

```
feature branch → PR → merge to main → (CI build + push image:sha)
                                              ↓
                                    git tag v1.x.x && git push origin v1.x.x
                                              ↓
                                    release.yml: re-tag + 更新 Helm values → ArgoCD 部署
```

## Test plan

- [ ] Merge 後確認 CI 跑 build + push image（tag: SHA）
- [ ] 打 `v0.1.0` tag 確認 release workflow 更新 Helm values

🤖 Generated with [Claude Code](https://claude.com/claude-code)