### PR TITLE
feat: remove count button from home page

### DIFF
--- a/app/src/components/HelloWorld.vue
+++ b/app/src/components/HelloWorld.vue
@@ -48,11 +48,6 @@ function maskSecret(value: string): string {
     <h1>🚀 GitOps Practice App</h1>
     <p class="subtitle">Vue 3 + Vite + Docker + Helm + Argo CD + Vault</p>
 
-    <div class="card">
-      <button @click="count++">Count is {{ count }}</button>
-      <p>Edit <code>src/components/HelloWorld.vue</code> to test HMR</p>
-    </div>
-
     <div class="info">
       <h2>Tech Stack</h2>
       <ul>

--- a/app/src/components/HelloWorld.vue
+++ b/app/src/components/HelloWorld.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 
-const count = ref(0)
 const buildTime = __BUILD_TIME__
 
 interface VaultConfig {


### PR DESCRIPTION
## Summary
- Remove the \"Count is 0\" button and its surrounding card div from the home page

## Test plan
- [ ] Verify home page no longer shows the count button
- [ ] Verify the rest of the page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)