### PR TITLE
feat: add emoji to Tech Stack heading

### DIFF
--- a/app/src/components/HelloWorld.vue
+++ b/app/src/components/HelloWorld.vue
@@ -48,7 +48,7 @@ function maskSecret(value: string): string {
     <p class="subtitle">Vue 3 + Vite + Docker + Helm + Argo CD + Vault</p>
 
     <div class="info">
-      <h2>Tech Stack</h2>
+      <h2>🛠️ Tech Stack</h2>
       <ul>
         <li>⚡ Vite — 極速打包工具</li>
         <li>💚 Vue 3 — Composition API</li>


### PR DESCRIPTION
## Summary
- Add 🛠️ emoji before "Tech Stack" heading on home page

## Test plan
- [ ] CI type check passes
- [ ] Vite build passes
- [ ] Visual: "🛠️ Tech Stack" renders correctly on home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)