### PR TITLE
feat: remove subtitle line from home page

### DIFF
--- a/app/src/components/HelloWorld.vue
+++ b/app/src/components/HelloWorld.vue
@@ -45,7 +45,6 @@ function maskSecret(value: string): string {
     </div>
 
     <h1>🚀 GitOps Practice App</h1>
-    <p class="subtitle">Vue 3 + Vite + Docker + Helm + Argo CD + Vault</p>
 
     <div class="info">
       <h2>🛠️ Tech Stack</h2>


### PR DESCRIPTION
## Summary
- 移除主頁標題下方的 `Vue 3 + Vite + Docker + Helm + Argo CD + Vault` 字串

## Test plan
- [ ] CI type check + build 通過
- [ ] Merge 後確認 dev 頁面（http://localhost:30080）subtitle 已移除

🤖 Generated with [Claude Code](https://claude.com/claude-code)