### PR TITLE
feat: add AI issue-to-PR automated workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai-bugfix.yml
+++ b/.github/ISSUE_TEMPLATE/ai-bugfix.yml
@@ -1,0 +1,51 @@
+name: "AI Bug 修復"
+description: "請 AI 自動修復 bug，填寫後加上 ai-task label 即可觸發"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        填寫完成後，對此 issue 加上 **`ai-task`** label，Claude 會自動修復並開 PR。
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug 描述
+      description: 請描述發生了什麼問題
+      placeholder: |
+        例如：HelloWorld.vue 在 build 後顯示 __BUILD_TIME__ 而不是實際的時間戳記
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 重現步驟
+      description: 如何重現這個 bug（選填）
+      placeholder: |
+        1. 執行 npm run build
+        2. 開啟 dist/index.html
+        3. 觀察頁面上的時間顯示
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 預期行為
+      description: 正確的行為應該是什麼（選填）
+      placeholder: |
+        應該顯示 build 時的實際 ISO 時間戳記，例如 2024-01-15T10:30:00.000Z
+    validations:
+      required: false
+
+  - type: textarea
+    id: files
+    attributes:
+      label: 可能有問題的檔案
+      description: 如果你知道問題出在哪個檔案（選填）
+      placeholder: |
+        app/vite.config.ts
+        app/src/components/HelloWorld.vue
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/ai-feature.yml
+++ b/.github/ISSUE_TEMPLATE/ai-feature.yml
@@ -1,0 +1,54 @@
+name: "AI 功能需求"
+description: "請 AI 自動實作新功能，填寫後加上 ai-task label 即可觸發"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        填寫完成後，對此 issue 加上 **`ai-task`** label，Claude 會自動實作並開 PR。
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 功能描述
+      description: 請詳細描述你希望實作的功能，越具體越好
+      placeholder: |
+        例如：在 HelloWorld.vue 的頁面頂部加上一個 badge，顯示目前環境（dev / prd）。
+        badge 樣式：綠色背景白字，讀取 import.meta.env.MODE 取得環境名稱。
+    validations:
+      required: true
+
+  - type: textarea
+    id: files
+    attributes:
+      label: 預期修改的檔案
+      description: 如果你知道需要改哪些檔案，請列出（選填）
+      placeholder: |
+        app/src/components/HelloWorld.vue
+        app/src/assets/main.css
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 驗收條件
+      description: PR 完成後如何驗證功能正確（選填）
+      placeholder: |
+        - npm run build 成功
+        - 頁面頂部顯示環境 badge
+        - dev 環境顯示綠色，prd 顯示藍色
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: 影響範圍
+      options:
+        - "前端 (app/)"
+        - "文件 (docs/)"
+        - "基礎設施 (infra/)"
+        - "其他"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -1,0 +1,56 @@
+name: Claude - Implement Issue
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  implement:
+    if: github.event.label.name == 'ai-task'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Implement with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          label_trigger: "ai-task"
+          branch_prefix: "claude/"
+          base_branch: "main"
+          track_progress: true
+          prompt: |
+            你是一個 AI 開發者，負責閱讀 GitHub issue 並實作程式碼變更。
+
+            ## 實作流程
+            1. 仔細閱讀 issue 的標題與描述
+            2. 分析需要修改的檔案
+            3. 實作變更
+            4. 在 app/ 目錄下執行 `npm install && npm run build` 驗證
+            5. 使用 Conventional Commits 格式 commit（feat:, fix:, docs:, chore:）
+            6. 建立 PR，描述使用繁體中文
+
+            ## 範圍限制
+            - 預設只修改 app/ 和 docs/ 目錄
+            - 若 issue 明確要求其他範圍（如 infra/），可以修改，但需在 PR 說明原因
+            - 絕對不修改 .github/workflows/ 下的任何檔案
+            - 不修改根目錄的 ArgoCD 設定檔（argocd-app-*.yaml）
+
+            ## 無法處理時
+            若遇到以下情況，在 issue 留言說明原因，不建立 PR：
+            - Issue 描述太模糊，無法判斷具體需求
+            - 需要大量架構變更（超過 10 個檔案）
+            - 涉及安全敏感操作（secrets、權限設定、外部 API key）
+          claude_args: "--max-turns 25"
+          additional_permissions: |
+            actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,3 +126,30 @@ gh run view <run_id> --log-failed
 ### Build Time 注入
 
 `app/vite.config.ts` 透過 `define: { __BUILD_TIME__ }` 在 build 時注入時間戳，前端可用 `__BUILD_TIME__` 全域變數顯示部署時間。
+
+## AI 自動實作模式（GitHub Actions 環境）
+
+當 Claude 透過 `claude-implement.yml` workflow 在 GitHub Actions 中執行時，遵循以下額外規則：
+
+### 觸發方式
+對 issue 加上 **`ai-task`** label → `claude-implement.yml` 自動觸發 → Claude 讀取 issue 並實作 → 開 PR 等待 review。
+
+### 範圍限制
+- 預設只修改 `app/` 和 `docs/` 目錄
+- 若 issue 明確要求其他範圍（如 `infra/`），可以修改，但需在 PR 說明原因
+- **絕對不修改** `.github/workflows/` 下的任何檔案（防止 workflow injection）
+- 不修改根目錄的 ArgoCD 設定檔（`argocd-app-*.yaml`）
+
+### 實作流程
+1. 仔細閱讀 issue 的標題、描述與驗收條件
+2. 分析需要修改的檔案
+3. 實作變更（TypeScript 優先，不寫 JavaScript）
+4. 在 `app/` 目錄下執行 `npm install && npm run build` 驗證
+5. 使用 Conventional Commits 格式 commit（`feat:`, `fix:`, `docs:`, `chore:`）
+6. 建立 PR，描述使用繁體中文
+
+### 無法處理的情況
+若遇到以下情況，在 issue 留言說明原因，**不建立 PR**：
+- Issue 描述太模糊，無法判斷具體需求
+- 需要大量架構變更（超過 10 個檔案）
+- 涉及安全敏感操作（secrets、權限設定、外部 API key）

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -1,0 +1,113 @@
+# AI 自動實作流程（Issue → PR）
+
+這個專案支援「AI 讀取 GitHub Issue → 自動實作 → 開 PR」的工作流程。  
+你只需要建立 issue 並加上 `ai-task` label，Claude 就會接手實作並開 PR 等待你 review。
+
+## 快速開始
+
+1. **建立 issue**：使用 issue template（AI 功能需求 或 AI Bug 修復）
+2. **加上 label**：對 issue 加上 `ai-task` label
+3. **等待 Claude 實作**：在 issue 頁面可以看到即時進度 checkbox
+4. **Review PR**：Claude 開好 PR 後，review 並 merge
+
+就這樣。
+
+## 完整流程圖
+
+```
+你建立 issue + 加上 "ai-task" label
+          │
+          ▼
+claude-implement.yml 自動觸發
+          │
+          ▼
+Claude 讀取 issue 內容
+          │
+          ▼
+建立 branch（claude/issue-N-描述）
+          │
+          ▼
+實作變更 → npm run build 驗證
+          │
+          ├─ 若 issue 太模糊或無法處理 → 在 issue 留言說明，結束
+          │
+          ▼
+push + 開 PR（描述用繁體中文）
+          │
+          ▼
+ci.yml 自動驗證（type check + build）
+          │
+          ▼
+你 review + merge PR
+          │
+          ▼
+cd-dev.yml → Docker build → 部署到 dev namespace
+```
+
+## Issue 撰寫技巧
+
+Claude 的實作品質取決於 issue 的描述品質。
+
+**好的 issue 範例：**
+```
+標題：在首頁加上環境 badge
+
+描述：
+在 HelloWorld.vue 的頁面頂部加上一個顯示目前環境的 badge。
+- 讀取 import.meta.env.MODE 取得環境名稱（development / production）
+- 樣式：圓角 badge，dev 顯示綠色，production 顯示藍色，白色文字
+- 位置：現有標題上方
+
+驗收條件：
+- npm run build 成功
+- 頁面上可以看到環境 badge
+```
+
+**不好的 issue 範例：**
+```
+標題：加個 badge
+
+描述：想要知道現在是哪個環境
+```
+
+## 注意事項
+
+### AI 的能力邊界
+
+Claude 適合處理：
+- 前端 UI 變更（Vue 元件、樣式）
+- 文件更新（docs/）
+- 小型功能新增（單一元件或少數檔案）
+- Bug 修復（有明確錯誤描述）
+
+Claude **不適合**處理：
+- 需要大量架構變更的功能
+- 涉及 secrets 或安全設定
+- 需要溝通才能釐清需求的模糊需求
+- Helm chart 或 ArgoCD 設定變更（需手動或用 `@claude` 詢問）
+
+### 若 Claude 說無法處理
+
+Claude 會在 issue 留言說明原因。你可以：
+1. 補充更詳細的描述，重新加上 `ai-task` label（remove 再 add）
+2. 自己實作，或用 `@claude` 在 PR 上請求協助
+
+### AI 建立的 PR 如何辨識
+
+- Branch 名稱以 `claude/` 開頭（例如 `claude/issue-5-add-env-badge`）
+- Commit 作者為 `claude[bot]`
+
+## 與現有 `@claude` 功能的差別
+
+| | `ai-task` label | `@claude` 提及 |
+|---|---|---|
+| **觸發方式** | 對 issue 加 label | 在 issue/PR 留言 `@claude xxx` |
+| **用途** | 完整實作一個需求 | 問問題、小修改、code review |
+| **結果** | 開一個完整的 PR | 直接在當前 PR push commit 或留言回答 |
+| **適合時機** | 你想讓 AI 從頭做一件事 | 你已有 PR，想要 AI 協助改進 |
+
+## 相關檔案
+
+- Workflow：`.github/workflows/claude-implement.yml`
+- Issue Templates：`.github/ISSUE_TEMPLATE/ai-feature.yml`、`ai-bugfix.yml`
+- AI 規則：`CLAUDE.md`（AI 自動實作模式章節）


### PR DESCRIPTION
## Summary

- 新增 `claude-implement.yml`：對 issue 加上 `ai-task` label 即觸發，Claude 自動實作並開 PR
- 升級 `claude.yml` permissions 為 write，讓 `@claude` 模式也能 push commits
- 新增 issue templates（AI 功能需求、AI Bug 修復），含結構化欄位與自動 label
- 更新 `CLAUDE.md`，新增 AI 自動實作模式的範圍限制與流程規則
- 新增 `docs/ai-workflow.md` 說明完整 Issue→PR 流程

## 使用方式

merge 後在 GitHub 建立 issue，加上 `ai-task` label，Claude 就會：
1. 讀取 issue 描述
2. 建立 `claude/issue-N-...` branch
3. 實作變更（預設只改 `app/` 和 `docs/`）
4. `npm run build` 驗證
5. 開 PR 等你 review

## 還需要手動建立 labels

```bash
gh label create "ai-task" --description "AI 自動實作" --color "7057ff"
gh label create "ai-implemented" --description "AI 已建立 PR" --color "0E8A16"
```

## Test plan

- [ ] merge 後手動建立 `ai-task` label
- [ ] 建立測試 issue 並加上 `ai-task` label
- [ ] 觀察 `claude-implement.yml` 是否觸發
- [ ] 確認 Claude 建立 `claude/` branch 並開 PR
- [ ] 確認 `ci.yml` 對 AI 的 PR 正常執行

🤖 Generated with [Claude Code](https://claude.com/claude-code)