### PR TITLE
fix(cd): prevent push rejection race condition with release-please

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -69,4 +69,5 @@ jobs:
           git config user.name "GitHub Actions"
           git add infra/helm/myapp/values-dev.yaml
           git commit -m "chore(dev): deploy ${{ github.sha }}"
+          git pull --rebase origin main
           git push


### PR DESCRIPTION
## Summary

- 在 `cd-dev.yml` 的 `git push` 前加上 `git pull --rebase origin main`

## 問題

PR merge 後，`cd-dev.yml` 和 `release-please.yml` 同時觸發。Release Please 跑很快（15秒），會先 push commit 到 main；而 `cd-dev.yml` 需要 build Docker image（~1.5 分鐘），push `values-dev.yaml` 時 main 已被移動，導致 `rejected - fetch first`。

## 修法

`git pull --rebase origin main` 把 Release Please 的 commit 拉下來再 push，避免衝突。

🤖 Generated with [Claude Code](https://claude.com/claude-code)