### PR TITLE
feat: 封面版本號加上底線

### DIFF
--- a/app/src/components/HelloWorld.vue
+++ b/app/src/components/HelloWorld.vue
@@ -90,7 +90,7 @@ function maskSecret(value: string): string {
       </div>
     </div>
 
-    <p class="build-info">Version: v{{ appVersion }} | Build time: {{ buildTime }}</p>
+    <p class="build-info">Version: <span class="version-number">v{{ appVersion }}</span> | Build time: {{ buildTime }}</p>
   </div>
 </template>
 
@@ -197,6 +197,10 @@ h1 {
   color: #666;
   font-size: 0.85rem;
   margin-top: 2rem;
+}
+
+.version-number {
+  text-decoration: underline;
 }
 
 .marquee-wrapper {


### PR DESCRIPTION
## 變更說明

封面的版本號加上底線樣式。

將 `v{{ appVersion }}` 包在 `<span class="version-number">` 內，並新增 CSS `text-decoration: underline`。

Closes #17

Generated with [Claude Code](https://claude.ai/code)