### PR TITLE
fix(cd): prevent SHA drift and race condition in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: main
+          fetch-depth: 0
 
       - name: Install tools
         run: |
@@ -46,7 +47,9 @@ jobs:
       - name: Read dev image SHA and promote
         run: |
           RELEASE_TAG="${{ github.event.inputs.tag || github.ref_name }}"
-          DEV_TAG=$(yq '.image.tag' infra/helm/myapp/values-dev.yaml)
+          # Read values-dev.yaml from the release tag commit (not current main HEAD)
+          # This prevents accidentally promoting a newer SHA that was deployed after the release tag was created
+          DEV_TAG=$(git show ${RELEASE_TAG}:infra/helm/myapp/values-dev.yaml | yq '.image.tag')
           echo "Promoting dev image: $DEV_TAG → $RELEASE_TAG"
 
           IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
@@ -61,4 +64,5 @@ jobs:
           git config user.name "GitHub Actions"
           git add infra/helm/myapp/values-prd.yaml
           git commit -m "chore(prd): release $RELEASE_TAG"
+          git pull --rebase origin main
           git push origin main


### PR DESCRIPTION
## 問題

### 問題一：race condition（git push 衝突）

`release.yml` 在更新 `values-prd.yaml` 後直接 `git push origin main`，沒有先 rebase。當 `cd-dev.yml` 幾乎同時在 push `chore(dev)` commit 時，其中一個會失敗。

`cd-dev.yml` 已在 93a0989 修過此問題，但 `release.yml` 漏掉了。

### 問題二：SHA drift（prd 部署到未 release 的 code）

`release.yml` checkout `main` 後，從當前 `values-dev.yaml` 讀取要 promote 的 SHA。問題在於：

1. Release PR merge → 建立 tag `app-v1.x.0`
2. 另一個 feature 同時或稍後 merge → `cd-dev.yml` 更新 `values-dev.yaml` 為新 SHA
3. `release.yml` 執行，checkout 最新 main → 讀到的是新 feature 的 SHA，而非 release 版本的

結果：prd 部署的 image 可能包含這次 release 沒有的功能。

## 修法

| 修改 | 說明 |
|------|------|
| `fetch-depth: 0` | 拿完整 git history，讓 `git show <tag>:...` 可以運作 |
| `git show ${RELEASE_TAG}:infra/helm/myapp/values-dev.yaml` | 從 **tag 所指向的 commit** 讀取 SHA，而非當前 main |
| `git pull --rebase origin main` | push 前先 rebase，與 `cd-dev.yml` 的保護一致 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)