### PR TITLE
fix(workflows): prevent chore commits from triggering release-please, add deployment verification

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -71,3 +71,19 @@ jobs:
           git commit -m "chore(dev): deploy ${{ github.sha }}"
           git pull --rebase origin main
           git push
+
+      - name: Verify deployment (requires KUBECONFIG_B64 secret)
+        env:
+          KUBECONFIG_DATA: ${{ secrets.KUBECONFIG_B64 }}
+        run: |
+          if [ -z "$KUBECONFIG_DATA" ]; then
+            echo "⚠️  KUBECONFIG_B64 secret not configured — skipping deployment verification"
+            echo "To enable: add a base64-encoded kubeconfig to repository secrets as KUBECONFIG_B64"
+            exit 0
+          fi
+          echo "$KUBECONFIG_DATA" | base64 -d > /tmp/kubeconfig
+          export KUBECONFIG=/tmp/kubeconfig
+          echo "Waiting for deployment myapp-dev to become available..."
+          kubectl wait --for=condition=available deployment/myapp-dev \
+            -n dev --timeout=120s
+          echo "✅ Deployment verified: myapp-dev is available in dev namespace"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,8 @@ name: Release Please
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'infra/helm/**'
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,3 +66,19 @@ jobs:
           git commit -m "chore(prd): release $RELEASE_TAG"
           git pull --rebase origin main
           git push origin main
+
+      - name: Verify deployment (requires KUBECONFIG_B64 secret)
+        env:
+          KUBECONFIG_DATA: ${{ secrets.KUBECONFIG_B64 }}
+        run: |
+          if [ -z "$KUBECONFIG_DATA" ]; then
+            echo "⚠️  KUBECONFIG_B64 secret not configured — skipping deployment verification"
+            echo "To enable: add a base64-encoded kubeconfig to repository secrets as KUBECONFIG_B64"
+            exit 0
+          fi
+          echo "$KUBECONFIG_DATA" | base64 -d > /tmp/kubeconfig
+          export KUBECONFIG=/tmp/kubeconfig
+          echo "Waiting for deployment myapp-prd to become available..."
+          kubectl wait --for=condition=available deployment/myapp-prd \
+            -n prd --timeout=180s
+          echo "✅ Deployment verified: myapp-prd is available in prd namespace"


### PR DESCRIPTION
## Summary

- **`release-please.yml`** 加上 `paths-ignore: infra/helm/**`，讓 `chore(dev)` / `chore(prd)` commit 不再觸發 release-please（closes #21，同時從 paths 層面杜絕 #22 的無限迴圈風險）
- **`cd-dev.yml`** 新增 `Verify deployment` step：若 repo secrets 有設定 `KUBECONFIG_B64`，自動等待 `myapp-dev` deployment available（closes #23）
- **`release.yml`** 同樣新增 `Verify deployment` step，等待 `myapp-prd` deployment available

## 各 issue 說明

### #21 — chore(dev) commit 不必要觸發 release-please

`release-please.yml` 新增：
```yaml
paths-ignore:
  - 'infra/helm/**'
```
`chore(dev)` 只更新 `infra/helm/myapp/values-dev.yaml`，符合 ignore 條件，不再觸發。

### #22 — 確認無限迴圈風險

雖然 GitHub 預設 `GITHUB_TOKEN` push 不觸發其他 workflow，但 `paths-ignore` 從 paths 層面提供第二道保護，無論 token 行為如何都不會誤觸 release-please。

### #23 — Deployment 成功驗證

兩個 workflow 結尾都加上驗證 step。設計為可選：
- 若 `KUBECONFIG_B64` secret 未設定 → 印出提示後 `exit 0`，不阻斷 workflow
- 若已設定 → 執行 `kubectl wait --for=condition=available`，真正確認 Pod ready

## Test plan

- [ ] Merge 一個 `app/**` PR 後，確認 `release-please.yml` 只被 merge commit 觸發一次，不被後續 `chore(dev)` commit 觸發
- [ ] 確認 `cd-dev.yml` 執行完後，`Verify deployment` step 顯示 skip 訊息（無 KUBECONFIG_B64）
- [ ] 若要測試完整驗證：設定 `KUBECONFIG_B64` secret 後，確認 step 等待 deployment ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)